### PR TITLE
Mocks the server property inside the already mocked session

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Fast Render can improve the initial load time of your app, giving you 2-10 times
   - [Client Error: "Server sent add for existing id"](#client-error-server-sent-add-for-existing-id)
   - [No data is injected when using "AppCache" package](#no-data-is-injected-when-using-appcache-package)
   - [No data is injected when using Meteor Subscription Cache](#no-data-is-injected-when-using-meteor-subscription-cache)
+  - [No support for publication strategies](#no-support-for-publication-strategies)
 - [Debugging](#debugging)
   - [Block DDP](#block-ddp)
   - [Get Payload](#get-payload)
@@ -204,6 +205,10 @@ Related Issue & Discussion: <https://github.com/kadirahq/fast-render/issues/136>
 ### No data is injected when using Meteor Subscription Cache
 
 When using the subscache package (`ccorcos:subs-cache` or `blockrazor:subscache-c4`) the parameters passed to the subscription must the identical on both Fast Render and Subscache or no data will be injected.
+
+### No support for publication strategies
+
+This package could affect the behavior of non-default [publication strategies](https://docs.meteor.com/api/pubsub.html#Publication-strategies). 
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ When using the subscache package (`ccorcos:subs-cache` or `blockrazor:subscache-
 
 ### No support for publication strategies
 
-This package could affect the behavior of non-default [publication strategies](https://docs.meteor.com/api/pubsub.html#Publication-strategies). 
+This package could affect the behavior of non-default [publication strategies](https://docs.meteor.com/api/pubsub.html#Publication-strategies).
 
 ## Debugging
 

--- a/lib/server/publish_context.js
+++ b/lib/server/publish_context.js
@@ -4,6 +4,16 @@ import { EJSON } from 'meteor/ejson';
 import { Meteor } from 'meteor/meteor';
 import { MeteorX } from 'meteor/montiapm:meteorx';
 
+// mock server
+const server = {
+  getPublicationStrategy () {
+    return {
+      useCollectionView: true,
+      doAccountingForCollection: true,
+    };
+  },
+};
+
 const PublishContext = function PublishContext (
   context,
   handler,
@@ -11,15 +21,6 @@ const PublishContext = function PublishContext (
   params,
   name,
 ) {
-  // mock server
-  const server = {
-    getPublicationStrategy() {
-      return {
-        useCollectionView: true,
-        doAccountingForCollection: true,
-      }
-    }
-  }
   // mock session
   const sessionId = Random.id();
   const session = {

--- a/lib/server/publish_context.js
+++ b/lib/server/publish_context.js
@@ -11,9 +11,19 @@ const PublishContext = function PublishContext (
   params,
   name,
 ) {
+  // mock server
+  const server = {
+    getPublicationStrategy() {
+      return {
+        useCollectionView: true,
+        doAccountingForCollection: true,
+      }
+    }
+  }
   // mock session
   const sessionId = Random.id();
   const session = {
+    server,
     id: sessionId,
     userId: context.userId,
     // not null


### PR DESCRIPTION
This PR is adding a mocked server to the already mocked session from fast-render to avoid errors like [this](https://forums.meteor.com/t/2-4-getpublicationstrategy/56671/24).