### PR TITLE
Update fast_render.js

### DIFF
--- a/lib/server/fast_render.js
+++ b/lib/server/fast_render.js
@@ -31,7 +31,7 @@ export const FastRender = {
   _routes: [],
   _onAllRoutes: [],
   _Context: Context,
-  frContext: new Meteor.EnvironmentVariable(),
+  frContext: DDP._CurrentInvocation,
 
   // handling specific routes
   route (path, callback) {


### PR DESCRIPTION
For SSR we should use DDP._CurrentInvocation. This way, Meteor.userId() is available within FastRender.onPageLoad.