### PR TITLE
Fixed addExtraData

### DIFF
--- a/lib/server/fast_render.js
+++ b/lib/server/fast_render.js
@@ -146,6 +146,7 @@ export const FastRender = {
       ).init();
 
       await FastRender.frContext.withValue(frContext, async function () {
+        await callback(sink);
         const context = FastRender.frContext.get();
         const data = context.getData();
         const extraData = context.getExtraData();
@@ -154,7 +155,7 @@ export const FastRender = {
           data,
           extraData,
         );
-        await callback(sink);
+    
       });
     });
   },


### PR DESCRIPTION
The callback had the wrong position, so we were not able to set any extra data (because it wasn't merged), f.e.:

server/main.js

```
FastRender.onPageLoad(async (sink) => {
...
 if(websiteId) FastRender.addExtraData('websiteId', websiteId);
});
```